### PR TITLE
Application status change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # Adopt, don't Shop
+#### Project started by Turing School of Software and Design
+#### The following work was completed by Bryce Simonds and Michael Bonini
 
 ### Existing database design
 ![visual-schema.png](https://i.postimg.cc/0ywZgQ1W/visual-schema.png)
+
+### Current database design
+![adopt_dont_shop](https://user-images.githubusercontent.com/16493270/179372459-b983a3d6-3269-473a-894b-39d6596714ae.png)
 
 ## Learning Goals
 

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -29,6 +29,13 @@ class ApplicationsController < ApplicationController
     redirect_to "/applications/#{app.id}"
   end
 
+  def update
+    app = Application.find(params[:id])
+    pet_application = app.pet_applications.find_by(pet_id: params[:pet_id].to_i)
+    pet_application.update(pet_status: params[:pet_status])
+    redirect_to "/admin/applications/#{app.id}"
+  end
+
   def admin
     redirect_to "/applications/#{params[:id]}?admin=true"
   end

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -9,10 +9,17 @@
 <div id="pets_in_application">
     <% @application.pets.each do |pet|%>
         <div id="pets-<%= pet.id %>">
-            <h4><%= link_to "#{pet.name}","/pets/#{pet.id}" %></h4>
+            <h4><%= link_to "#{pet.name}","/pets/#{pet.id}?" %></h4>
             <% unless @admin.nil? %>
-                <%= button_to "Approve", "/admin/applications/#{@application.id}" %>
-                <%= button_to "Reject", "/admin/applications/#{@application.id}" %>
+                <% pet_application = @application.pet_applications.find_by(pet_id: pet.id) %>
+                <% if pet_application.pet_status == 'approved'%>
+                    <h4> Approved </h4>
+                <% elsif pet_application.pet_status == 'rejected' %>
+                    <h4> Rejected </h4>
+                <% else %>
+                    <%= button_to "Approve", "/admin/applications/#{@application.id}?pet_status=approved&pet_id=#{pet.id}", method: :patch %>
+                    <%= button_to "Reject", "/admin/applications/#{@application.id}?pet_status=rejected&pet_id=#{pet.id}", method: :patch %>
+                <% end %>
             <% end %>
         </div>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
   patch '/applications/:id', to: 'applications#submit'
   post '/applications', to: 'applications#create'
   get '/admin/applications/:id', to: 'applications#admin'
+  patch '/admin/applications/:id', to: 'applications#update'
 
   post '/pet_applications/:pet_id/:application_id', to: 'pet_applications#create'
 end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe 'the application show' do
       click_on("Approve")
     end 
 
-    expect(current_path).to eq("/admin/applications/#{applications.id}")
+    expect(current_path).to eq("/applications/#{application.id}")
 
     within "#pets-#{scooby.id}" do 
       expect(page).to have_content("Approved")
@@ -289,7 +289,7 @@ RSpec.describe 'the application show' do
       click_on("Reject")
     end 
 
-    expect(current_path).to eq("/admin/applications/#{applications.id}")
+    expect(current_path).to eq("/applications/#{application.id}")
 
     within "#pets-#{scooby.id}" do 
       expect(page).to have_content("Rejected")

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -302,4 +302,36 @@ RSpec.describe 'the application show' do
       expect(page).to have_button("Reject")
     end 
   end
+
+  it 'approved or rejected pets do not affect other apps' do
+    application = Application.create!(name: 'John Doe', street_address: '123 apple street', city: 'Denver', state: 'CO', zipcode: '90210', description: 'we love pets', status: 'In Progress')
+    application_2 = Application.create!(name: 'Jane Doe', street_address: 'pear street', city: 'NYC', state: 'NY', zipcode: '95732', description: 'I am lonely', status: 'In Progress')
+    shelter = Shelter.create!(name: 'Mystery Building', city: 'Irvine CA', foster_program: false, rank: 9)
+    scooby = Pet.create!(name: 'Scooby', age: 2, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
+    clifford = Pet.create!(name: 'Clifford', age: 1, breed: 'Red Dog', adoptable: true, shelter_id: shelter.id)
+
+    PetApplication.create!(pet: scooby, application: application)
+    PetApplication.create!(pet: scooby, application: application_2)
+
+    visit "/admin/applications/#{application.id}"
+
+    within "#pets-#{scooby.id}" do 
+      click_on("Reject")
+    end 
+
+    expect(current_path).to eq("/applications/#{application.id}")
+
+    within "#pets-#{scooby.id}" do 
+      expect(page).to have_content("Rejected")
+      expect(page).to_not have_button("Approve")
+      expect(page).to_not have_button("Reject")
+    end
+
+    visit "/admin/applications/#{application_2.id}"
+
+    within "#pets-#{scooby.id}" do 
+      expect(page).to have_button("Approve")
+      expect(page).to have_button("Reject")
+    end 
+  end
 end


### PR DESCRIPTION
## Pull request type
Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Problem/feature

_What problem are you trying to solve?_

Approving a Pet for Adoption

As a visitor
When I visit an admin application show page ('/admin/applications/:id')
For every pet that the application is for, I see a button to approve the application for that specific pet
When I click that button
Then I'm taken back to the admin application show page
And next to the pet that I approved, I do not see a button to approve this pet
And instead I see an indicator next to the pet that they have been approved

Rejecting a Pet for Adoption

As a visitor
When I visit an admin application show page ('/admin/applications/:id')
For every pet that the application is for, I see a button to reject the application for that specific pet
When I click that button
Then I'm taken back to the admin application show page
And next to the pet that I rejected, I do not see a button to approve or reject this pet
And instead I see an indicator next to the pet that they have been rejected
Approved/Rejected Pets on one Application do not affect other Applications

As a visitor
When there are two applications in the system for the same pet
When I visit the admin application show page for one of the applications
And I approve or reject the pet for that application
When I visit the other application's admin show page
Then I do not see that the pet has been accepted or rejected for that application
And instead I see buttons to approve or reject the pet for this specific application


## Other changes (e.g. bug fixes, UI tweaks, small refactors)

## Checklist
- [x] Code compiles correctly
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary