### PR TITLE
Pet status buttons redirect & faker in seed data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ group :development, :test do
   gem 'pry'
   gem 'rspec-rails'
   gem 'simplecov'
+  gem 'faker'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,8 @@ GEM
     docile (1.4.0)
     erubi (1.10.0)
     execjs (2.8.1)
+    faker (2.21.0)
+      i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -227,6 +229,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   capybara
   coffee-rails (~> 4.2)
+  faker
   jbuilder (~> 2.5)
   launchy
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -29,13 +29,6 @@ class ApplicationsController < ApplicationController
     redirect_to "/applications/#{app.id}"
   end
 
-  def update
-    app = Application.find(params[:id])
-    pet_application = app.pet_applications.find_by(pet_id: params[:pet_id].to_i)
-    pet_application.update(pet_status: params[:pet_status])
-    redirect_to "/admin/applications/#{app.id}"
-  end
-
   def admin
     redirect_to "/applications/#{params[:id]}?admin=true"
   end

--- a/app/controllers/pet_applications_controller.rb
+++ b/app/controllers/pet_applications_controller.rb
@@ -5,6 +5,13 @@ class PetApplicationsController < ApplicationController
         pet_application_association = PetApplication.create!(pet: pet, application: application)
         redirect_to "/applications/#{application.id}"
     end
+
+    def update
+        app = Application.find(params[:application_id])
+        pet_application = app.pet_applications.find_by(pet_id: params[:pet_id].to_i)
+        pet_application.update(pet_status: params[:pet_status])
+        redirect_to "/admin/applications/#{app.id}"
+      end
 end
 
 

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -17,8 +17,8 @@
                 <% elsif pet_application.pet_status == 'rejected' %>
                     <h4> Rejected </h4>
                 <% else %>
-                    <%= button_to "Approve", "/admin/applications/#{@application.id}?pet_status=approved&pet_id=#{pet.id}", method: :patch %>
-                    <%= button_to "Reject", "/admin/applications/#{@application.id}?pet_status=rejected&pet_id=#{pet.id}", method: :patch %>
+                    <%= button_to "Approve", "/pet_applications/#{pet.id}/#{@application.id}?pet_status=approved", method: :patch %>
+                    <%= button_to "Reject", "/pet_applications/#{pet.id}/#{@application.id}?pet_status=rejected", method: :patch %>
                 <% end %>
             <% end %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,8 @@ Rails.application.routes.draw do
   patch '/applications/:id', to: 'applications#submit'
   post '/applications', to: 'applications#create'
   get '/admin/applications/:id', to: 'applications#admin'
-  patch '/admin/applications/:id', to: 'applications#update'
+  # patch '/admin/applications/:id', to: 'applications#update'
 
   post '/pet_applications/:pet_id/:application_id', to: 'pet_applications#create'
+  patch '/pet_applications/:pet_id/:application_id', to: 'pet_applications#update'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,6 @@ Rails.application.routes.draw do
   patch '/applications/:id', to: 'applications#submit'
   post '/applications', to: 'applications#create'
   get '/admin/applications/:id', to: 'applications#admin'
-  # patch '/admin/applications/:id', to: 'applications#update'
 
   post '/pet_applications/:pet_id/:application_id', to: 'pet_applications#create'
   patch '/pet_applications/:pet_id/:application_id', to: 'pet_applications#update'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,15 +1,37 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+require 'faker'
 
-application = Application.create!(name: 'John Doe', street_address: '123 apple street', city: 'Denver', state: 'CO', zipcode: '90210', description: 'we love pets', status: 'In Progress')
-shelter = Shelter.create!(name: 'Mystery Building', city: 'Irvine CA', foster_program: false, rank: 9)
-scooby = Pet.create!(name: 'Scooby', age: 2, breed: 'Great Dane', adoptable: true, shelter_id: shelter.id)
-clifford = Pet.create!(name: 'Clifford', age: 1, breed: 'Red Dog', adoptable: true, shelter_id: shelter.id)
-rudolph = Pet.create!(name: 'Rudolph', age: 100, breed: 'Not Sure', adoptable: false, shelter_id: shelter.id)
+5.times do 
+    Application.create!(
+        name: Faker::Name.name, 
+        street_address: Faker::Address.street_address, 
+        city: Faker::Address.city, 
+        state: Faker::Address.state_abbr,
+        zipcode: Faker::Address.zip, 
+        description: Faker::Hipster.sentence, 
+        status: 'In Progress'
+    )
+end
 
-scooby_application = PetApplication.create!(pet: scooby, application: application)
+5.times do
+    Shelter.create!(
+        name: Faker::Company.name, 
+        city: Faker::Address.city,
+        foster_program: Faker::Boolean.boolean,
+        rank: Faker::Number.within(range: 1..10)
+    )
+end
+
+20.times do
+    Pet.create!(
+        name: Faker::Hipster.word, 
+        age: Faker::Number.within(range: 1..10), 
+        breed: Faker::Creature::Animal.name, 
+        adoptable: true, 
+        shelter_id: rand(1..5)
+    )
+end
+
+pet_application_1 = PetApplication.create!(pet: Pet.all.sample, application: Application.first)
+pet_application_2 = PetApplication.create!(pet: Pet.all.sample, application: Application.first)
+pet_application_3 = PetApplication.create!(pet: Pet.all.sample, application: Application.second)
+pet_application_4 = PetApplication.create!(pet: Pet.all.sample, application: Application.third)


### PR DESCRIPTION
## Pull request type
Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Problem/feature

_What problem are you trying to solve?_

Approving a Pet for Adoption
As a visitor
When I visit an admin application show page ('/admin/applications/:id')
For every pet that the application is for, I see a button to approve the application for that specific pet
When I click that button
Then I'm taken back to the admin application show page
And next to the pet that I approved, I do not see a button to approve this pet
And instead I see an indicator next to the pet that they have been approved

Rejecting a Pet for Adoption

As a visitor
When I visit an admin application show page ('/admin/applications/:id')
For every pet that the application is for, I see a button to reject the application for that specific pet
When I click that button
Then I'm taken back to the admin application show page
And next to the pet that I rejected, I do not see a button to approve or reject this pet
And instead I see an indicator next to the pet that they have been rejected
## Solution

Add faker to increase seed data
## Checklist
- [x] Code compiles correctly
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary